### PR TITLE
Refactor: Translate dialogs module from French to English (Part 1)

### DIFF
--- a/dialogs/configuration.cpp
+++ b/dialogs/configuration.cpp
@@ -17,9 +17,9 @@ Configuration::Configuration(const QString&fileNameXML, const QString&fileNameSQ
 {
     // translator
     QTranslator translator;
-    QString     fichier = ":/translations/open-jardin_" + util::getLocale();
+    QString     fileContent = ":/translations/open-jardin_" + util::getLocale();
 
-    translator.load(fichier);
+    translator.load(fileContent);
     qApp->installTranslator(&translator);
 
     ui->setupUi(this);
@@ -47,7 +47,7 @@ void Configuration::on_pushButton_fermer_clicked()
     close();
 }
 
-/****************remplacement des apostrophes dans les QString pour les requêtes sql*************/
+/****************replacement of apostrophes in QStrings for sql queries*************/
 
 
 void Configuration::createConnection(QString fileName)
@@ -56,8 +56,8 @@ void Configuration::createConnection(QString fileName)
 
     if (!file.open(QFile::ReadOnly | QFile::Text))
     {
-        ui->plainTextMessages->insertPlainText("Erreur de lecture du fichier : " + fileName + "\n");
-        ui->plainTextMessages->insertPlainText("Vérifier le chemin d'accès au fichier !!\n");
+        ui->plainTextMessages->insertPlainText("Error reading file: " + fileName + "\n");
+        ui->plainTextMessages->insertPlainText("Check the file path!!\n");
         return;
     }
     QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
@@ -67,20 +67,20 @@ void Configuration::createConnection(QString fileName)
     db.setDatabaseName(fileName);
     if (!db.open())
     {
-        qDebug() << "connection database erreur " << fileName;
+        qDebug() << "database connection error " << fileName;
     }
     else
     {
         qDebug() << "database open " << fileName;
         ui->lineEdit_config_nom_base->setText(fileName);
-        ui->plainTextMessages->insertPlainText("Base de données ouverte : " + fileName + "\n");
+        ui->plainTextMessages->insertPlainText("Database opened: " + fileName + "\n");
     }
     setSqlFileName(fileName);
 }
 
 void Configuration::init_base()
-{   /***********************initialisation des bases de données sqlite******************/
-    //TACHES
+{   /***********************initialization of sqlite databases******************/
+    //TASKS
     QSqlQueryModel *model4 = new QSqlQueryModel;
 
     model4->setQuery("SELECT id,designation FROM taches ORDER BY designation ASC");
@@ -91,13 +91,13 @@ void Configuration::init_base()
 
 void Configuration::on_pushButton_changeDataBase_clicked()
 {
-    // changer la base de données active
+    // change the active database
     QSqlQuery query;
-    QString   repertoire = QDir::homePath() + "/openjardin/";
+    QString   directory = QDir::homePath() + "/openjardin/";
 
     QString fileName =
-        QFileDialog::getOpenFileName(this, tr("Ouverture d'une base de données"),
-                                     repertoire,
+        QFileDialog::getOpenFileName(this, tr("Open a database"),
+                                     directory,
                                      tr("SQLI files (*.sqli *.db);; All files (*.*) "));
 
     // tr("SQLI Files (*.sqli *.db)"));
@@ -110,43 +110,43 @@ void Configuration::on_pushButton_changeDataBase_clicked()
     QFile file(fileName);
     if (!file.open(QFile::ReadOnly | QFile::Text))
     {
-        ui->plainTextMessages->insertPlainText("Erreur de lecture du fichier : " + fileName + "\n");
+        ui->plainTextMessages->insertPlainText("Error reading file: " + fileName + "\n");
         return;
     }
     else
     {
-        ui->plainTextMessages->insertPlainText("Base de données ouverte :" + fileName + "\n");
+        ui->plainTextMessages->insertPlainText("Database opened:" + fileName + "\n");
         createConnection(fileName);
     }
 }
 
 void Configuration::enregistrerDataBase()
 {
-    // enregistrer le nom de la base de données dans le fichier XML
+    // save the name of the database in the XML file
     QString      cellvalue;
-    QString      champ;
+    QString      field;
     QDomDocument document;
     QDomNode     xmlNode = document.createProcessingInstruction("xml", "version=\"1.0\" encoding=\"UTF-8\"");
 
     document.insertBefore(xmlNode, document.firstChild());
     QDomElement root = document.createElement("root");
     document.appendChild(root);
-    // Création de l'élément <base>
+    // Create the <base> element
     QDomElement base = document.createElement("base");
 
-    // On ajoute l'élément <background> en tant que premier enfant de l'élément <root>
+    // Add the <background> element as the first child of the <root> element
     root.appendChild(base);
-    //Ecriture du nom du fichier de la base de données sqlite
-    QDomElement fichier_base = document.createElement("fichier_base");
+    //Write the name of the sqlite database file
+    QDomElement file_base = document.createElement("file_base");
     cellvalue = ui->lineEdit_config_nom_base->text();
-    champ     = "fichier";
-    fichier_base.setAttribute(champ, cellvalue);
-    base.appendChild(fichier_base);
-    // Ecriture dans le fichier
-    QString repertoire = QDir::homePath() + "/openjardin";
+    field     = "file";
+    file_base.setAttribute(field, cellvalue);
+    base.appendChild(file_base);
+    // Write to file
+    QString directory = QDir::homePath() + "/openjardin";
     QString fileName   =
-        QFileDialog::getSaveFileName(this, tr("Sauvegarde du tableau des objets"),
-                                     repertoire,
+        QFileDialog::getSaveFileName(this, tr("Save object table"),
+                                     directory,
                                      tr("XML Files (*.xml)"));
     if (fileName.isEmpty())
     {
@@ -157,7 +157,7 @@ void Configuration::enregistrerDataBase()
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         QMessageBox msgBox;
-        msgBox.setText("ERREUR D'ÉCRITURE");
+        msgBox.setText("WRITE ERROR");
         return;
     }
     else
@@ -170,12 +170,12 @@ void Configuration::enregistrerDataBase()
 
 void Configuration::on_pushButton_NewdatabaseFull_clicked()
 {
-    //  créer une base vide et importer les données dans cette base de données
-    ui->plainTextMessages->insertPlainText("Début de l'importation des données\n");
-    QString repertoire = QDir::homePath() + "/openjardin";
+    //  create an empty database and import data into this database
+    ui->plainTextMessages->insertPlainText("Starting data import\n");
+    QString directory = QDir::homePath() + "/openjardin";
     QString fileName   =
-        QFileDialog::getSaveFileName(this, tr("Créer une nouvelle base de données préremplie"),
-                                     repertoire,
+        QFileDialog::getSaveFileName(this, tr("Create a new pre-filled database"),
+                                     directory,
                                      tr("SQLI Files (*.sqli *.db)"));
     if (fileName.isEmpty())
     {
@@ -186,7 +186,7 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         QMessageBox msgBox;
-        msgBox.setText("ERREUR D'ÉCRITURE");
+        msgBox.setText("WRITE ERROR");
         return;
     }
     else
@@ -198,19 +198,19 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
         db.setDatabaseName(fileName);
         if (!db.open())
         {
-            qDebug() << "connection database erreur " << fileName;
+            qDebug() << "database connection error " << fileName;
         }
         else
         {
             qDebug() << "database open " << fileName;
-            ui->plainTextMessages->insertPlainText("Base de données ouverte :" + fileName + "\n");
+            ui->plainTextMessages->insertPlainText("Database opened:" + fileName + "\n");
         }
         QString queryStr;
         QFile   file(":/sql/restore.sql");
         if (!file.open(QFile::ReadOnly | QFile::Text))
         {
             QMessageBox msgBox;
-            msgBox.setText("ERREUR D'ÉCRITURE");
+            msgBox.setText("WRITE ERROR");
             return;
         }
         else
@@ -226,21 +226,21 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
 
 
 
-        ui->plainTextMessages->insertPlainText("Données importée dans la nouvelle base \n");
-        //Vérifier si le driver SQL supporte les Transactions
+        ui->plainTextMessages->insertPlainText("Data imported into the new database \n");
+        //Check if the SQL driver supports Transactions
         if (db.driver()->hasFeature(QSqlDriver::Transactions))
         {
-            //Remplace les commentaires, tabulations et nouvelles lignes avec des espaces
+            //Replace comments, tabs and newlines with spaces
             queryStr =
                 queryStr.replace(QRegularExpression("(\\/\\*(.|\\n)*?\\*\\/|^--.*\\n|\\t|\\n)",
                                                     QRegularExpression::CaseInsensitiveOption |
                                                     QRegularExpression::MultilineOption), " ");
-            //Supprimer les espaces inutiles
+            //Remove unnecessary spaces
             queryStr = queryStr.trimmed();
 
-            //Extraction des requêtes
+            //Extract queries
             QStringList qList = queryStr.split(';', QString::SkipEmptyParts);
-            //Initialise les expressions pour détecter les requêts spéciales(`begin transaction` and `commit`).
+            //Initialize expressions to detect special queries (`begin transaction` and `commit`).
             QRegularExpression re_transaction("\\bbegin.transaction.*", QRegularExpression::CaseInsensitiveOption);
             QRegularExpression re_commit("\\bcommit.*", QRegularExpression::CaseInsensitiveOption);
 
@@ -249,26 +249,26 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
             {
                 db.transaction();
             }
-            //Executer chaque requête individuellement
+            //Execute each query individually
 
             foreach(const QString &s, qList)
             {
-                if (re_transaction.match(s).hasMatch())        //<== detection des requêtes spéciales
+                if (re_transaction.match(s).hasMatch())        //<== detect special queries
                 {
                     db.transaction();
                 }
-                else if (re_commit.match(s).hasMatch())        //<== detection des requêtes spéciales
+                else if (re_commit.match(s).hasMatch())        //<== detect special queries
                 {
                     db.commit();
                 }
                 else
                 {
-                    query.exec(s);                             //<== executer les requêtes normales
+                    query.exec(s);                             //<== execute normal queries
                     if (query.lastError().type() != QSqlError::NoError)
                     {
-                        // qDebug() << "erreur 262 " << query.lastError().text() << query.lastQuery();
+                        // qDebug() << "error 262 " << query.lastError().text() << query.lastQuery();
 
-                        db.rollback();                         //<== rollback la transaction s'il y a un probême
+                        db.rollback();                         //<== rollback the transaction if there is a problem
                         ui->plainTextMessages->insertPlainText(query.lastError().databaseText() + " \n");
                     }
                     else
@@ -277,7 +277,7 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
                     }
                 }
             }
-            ui->plainTextMessages->insertPlainText("Importation des données terminée \n");
+            ui->plainTextMessages->insertPlainText("Data import finished \n");
 
             if (!isStartedWithTransaction)
             {
@@ -285,8 +285,8 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
             }
         }
         else
-        {         //si le driver sql ne support pas les transactions
-                  //...il est nécessaire de supprimer les requêtes spéciales(`begin transaction` and `commit`)
+        {         //if the sql driver does not support transactions
+                  //...it is necessary to delete special queries (`begin transaction` and `commit`)
             queryStr =
                 queryStr.replace(QRegularExpression(
                                      "(\\bbegin.transaction.*;|\\bcommit.*;|\\/\\*(.|\\n)*?\\*\\/|^--.*\\n|\\t|\\n)",
@@ -294,7 +294,7 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
                                      QRegularExpression::MultilineOption), " ");
             queryStr = queryStr.trimmed();
 
-            //Executer chaque requête individuellement
+            //Execute each query individually
             QStringList qList = queryStr.split(';', QString::SkipEmptyParts);
             foreach(const QString &s, qList)
             {
@@ -306,7 +306,7 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
                 else
                 {
                 }
-                ui->plainTextMessages->insertPlainText("Importation des données terminée \n");
+                ui->plainTextMessages->insertPlainText("Data import finished \n");
             }
         }
     }
@@ -314,12 +314,12 @@ void Configuration::on_pushButton_NewdatabaseFull_clicked()
 
 void Configuration::on_pushButton_import_clicked()
 {
-    //  créer une base vide et importer les données dans cette base de données
-    ui->plainTextMessages->insertPlainText("Début de l'importation des données\n");
-    QString repertoire = QDir::homePath() + "/openjardin";
+    //  create an empty database and import data into this database
+    ui->plainTextMessages->insertPlainText("Starting data import\n");
+    QString directory = QDir::homePath() + "/openjardin";
     QString fileName   =
-        QFileDialog::getSaveFileName(this, tr("Nom de la nouvelle base de données"),
-                                     repertoire,
+        QFileDialog::getSaveFileName(this, tr("New database name"),
+                                     directory,
                                      tr("SQLI Files (*.sqli *.db)"));
     if (fileName.isEmpty())
     {
@@ -330,7 +330,7 @@ void Configuration::on_pushButton_import_clicked()
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         QMessageBox msgBox;
-        msgBox.setText("ERREUR D'ÉCRITURE");
+        msgBox.setText("WRITE ERROR");
         return;
     }
     else
@@ -342,21 +342,21 @@ void Configuration::on_pushButton_import_clicked()
         db.setDatabaseName(fileName);
         if (!db.open())
         {
-            qDebug() << "connection database erreur " << fileName;
+            qDebug() << "database connection error " << fileName;
         }
         else
         {
             qDebug() << "database open " << fileName;
-            ui->plainTextMessages->insertPlainText("Base de données ouverte :" + fileName + "\n");
+            ui->plainTextMessages->insertPlainText("Database opened:" + fileName + "\n");
         }
 
         QSqlQuery query;
-        QString   repertoire = QDir::homePath() + "/openjardin/";
+        QString   directory = QDir::homePath() + "/openjardin/";
 
         QString fileNameImport =
-            QFileDialog::getOpenFileName(this, tr("Choisir le fichier .sql à importer dans la base de données"),
-                                         repertoire,
-                                         tr("fichier SQL (*.sql)"));
+            QFileDialog::getOpenFileName(this, tr("Choose the .sql file to import into the database"),
+                                         directory,
+                                         tr("SQL file (*.sql)"));
         if (fileNameImport.isEmpty())
         {
             return;
@@ -366,31 +366,31 @@ void Configuration::on_pushButton_import_clicked()
         if (!fileImport.open(QFile::ReadOnly | QFile::Text))
         {
             QMessageBox msgBox;
-            msgBox.setText("ERREUR DE LECTURE");
+            msgBox.setText("READ ERROR");
             return;
         }
         else
         {
-            //lecture du fichier .sql
+            //read the .sql file
             QTextStream Str(&fileImport);
             QString     queryStr;
             queryStr = Str.readAll();
             fileImport.close();
-            ui->plainTextMessages->insertPlainText("Fichier importé :" + fileNameImport + "\n");
-            //Vérifier si le driver SQL supporte les Transactions
+            ui->plainTextMessages->insertPlainText("File imported:" + fileNameImport + "\n");
+            //Check if the SQL driver supports Transactions
             if (db.driver()->hasFeature(QSqlDriver::Transactions))
             {
-                //Remplace les commentaires, tabulations et nouvelles lignes avec des espaces
+                //Replace comments, tabs and newlines with spaces
                 queryStr =
                     queryStr.replace(QRegularExpression("(\\/\\*(.|\\n)*?\\*\\/|^--.*\\n|\\t|\\n)",
                                                         QRegularExpression::CaseInsensitiveOption |
                                                         QRegularExpression::MultilineOption), " ");
-                //Supprimer les espaces inutiles
+                //Remove unnecessary spaces
                 queryStr = queryStr.trimmed();
 
-                //Extraction des requêtes
+                //Extract queries
                 QStringList qList = queryStr.split(';', QString::SkipEmptyParts);
-                //Initialise les expressions pour détecter les requêts spéciales(`begin transaction` and `commit`).
+                //Initialize expressions to detect special queries (`begin transaction` and `commit`).
                 QRegularExpression re_transaction("\\bbegin.transaction.*", QRegularExpression::CaseInsensitiveOption);
                 QRegularExpression re_commit("\\bcommit.*", QRegularExpression::CaseInsensitiveOption);
 
@@ -399,39 +399,39 @@ void Configuration::on_pushButton_import_clicked()
                 {
                     db.transaction();
                 }
-                //Executer chaque requête individuellement
+                //Execute each query individually
                 foreach(const QString &s, qList)
                 {
-                    if (re_transaction.match(s).hasMatch())    //<== detection des requêtes spéciales
+                    if (re_transaction.match(s).hasMatch())    //<== detect special queries
                     {
                         db.transaction();
                     }
-                    else if (re_commit.match(s).hasMatch())    //<== detection des requêtes spéciales
+                    else if (re_commit.match(s).hasMatch())    //<== detect special queries
                     {
                         db.commit();
                     }
                     else
                     {
-                        query.exec(s);                        //<== executer les requêtes normales
+                        query.exec(s);                        //<== execute normal queries
                         if (query.lastError().type() != QSqlError::NoError)
                         {
                             qDebug() << query.lastError().text();
                             qDebug() << s;
-                            db.rollback();                    //<== rollback la transaction s'il y a un probême
+                            db.rollback();                    //<== rollback the transaction if there is a problem
                             ui->plainTextMessages->insertPlainText(query.lastError().databaseText() + " \n");
                         }
                     }
                 }
-                ui->plainTextMessages->insertPlainText("Importation des données terminée \n");
+                ui->plainTextMessages->insertPlainText("Data import finished \n");
 
                 if (!isStartedWithTransaction)
                 {
                     db.commit();
                 }
             }
-            else  //si le driver sql ne support pas les transactions
+            else  //if the sql driver does not support transactions
 
-            {     //...il est nécessaire de supprimer les requêtes spéciales(`begin transaction` and `commit`)
+            {     //...it is necessary to delete special queries (`begin transaction` and `commit`)
                 queryStr =
                     queryStr.replace(QRegularExpression(
                                          "(\\bbegin.transaction.*;|\\bcommit.*;|\\/\\*(.|\\n)*?\\*\\/|^--.*\\n|\\t|\\n)",
@@ -439,7 +439,7 @@ void Configuration::on_pushButton_import_clicked()
                                          QRegularExpression::MultilineOption), " ");
                 queryStr = queryStr.trimmed();
 
-                //Executer chaque requête individuellement
+                //Execute each query individually
                 QStringList qList = queryStr.split(';', QString::SkipEmptyParts);
                 foreach(const QString &s, qList)
                 {
@@ -452,22 +452,22 @@ void Configuration::on_pushButton_import_clicked()
                     else
                     {
                     }
-                    ui->plainTextMessages->insertPlainText("Importation des données terminée \n");
+                    ui->plainTextMessages->insertPlainText("Data import finished \n");
                 }
             }
         }
     }
 }
 
-/**********************************EXPORT VERS UN FICHIER TEXTE DES REQUETTES SQL************************/
+/**********************************EXPORT TO A TEXT FILE OF SQL QUERIES************************/
 void Configuration::on_pushButton_export_clicked()
 {
-    // export des données dans un fichier de requêtes .sql
-    QString repertoire = QDir::homePath() + "/openjardin";
+    // export data to a .sql query file
+    QString directory = QDir::homePath() + "/openjardin";
     QString fileName   =
-        QFileDialog::getSaveFileName(this, tr("Création d'un export de la base de données"),
-                                     repertoire,
-                                     tr("Fichier SQL (*.sql)"));
+        QFileDialog::getSaveFileName(this, tr("Create a database export"),
+                                     directory,
+                                     tr("SQL File (*.sql)"));
 
     if (fileName.isEmpty())
     {
@@ -478,7 +478,7 @@ void Configuration::on_pushButton_export_clicked()
     if (!file.open(QFile::WriteOnly | QFile::Text))
     {
         QMessageBox msgBox;
-        msgBox.setText("ERREUR D'ÉCRITURE");
+        msgBox.setText("WRITE ERROR");
         return;
     }
     else
@@ -489,8 +489,8 @@ void Configuration::on_pushButton_export_clicked()
         QStringList tables;
         query.exec("SELECT * FROM sqlite_master ");
         int     i2 = 0;
-        QString valeur_tables;
-        //requêtes CREATE des tables
+        QString table_values;
+        //CREATE table queries
         while (query.next())
         {
             if (i2 > 0)
@@ -499,16 +499,16 @@ void Configuration::on_pushButton_export_clicked()
                 {
                     tables << query.value("name").toString();
                 }
-                valeur_tables = query.value("sql").toString();
-                valeur_tables.replace(QString("\""), QString("`"));
-                valeur_tables.replace(QString("\n"), QString(""));
-                valeur_tables.replace(QString("\t"), QString(" "));
-                qDebug().noquote() << valeur_tables.toUtf8() << ";\n";;
-                stream << valeur_tables.toUtf8().constData() << ";\n";
+                table_values = query.value("sql").toString();
+                table_values.replace(QString("\""), QString("`"));
+                table_values.replace(QString("\n"), QString(""));
+                table_values.replace(QString("\t"), QString(" "));
+                qDebug().noquote() << table_values.toUtf8() << ";\n";;
+                stream << table_values.toUtf8().constData() << ";\n";
             }
             i2++;
         }
-        //requêtes INSERT des données
+        //INSERT data queries
         QString    values;
         QString    columns;
         QString    insert;
@@ -583,11 +583,11 @@ void Configuration::on_pushButton_Modifier_operations_clicked()
 
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
     }
     else
     {
-        qDebug() << "enregistrement terminé";
+        qDebug() << "record finished";
     }
 
     QSqlQueryModel *model4 = new QSqlQueryModel;
@@ -603,7 +603,7 @@ void Configuration::on_pushButton_Supprimer_operations_clicked()
 {
     QMessageBox msgBox;
 
-    msgBox.setInformativeText("Voulez-vous supprimer cette opération ?");
+    msgBox.setInformativeText("Do you want to delete this operation?");
     msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
     msgBox.setDefaultButton(QMessageBox::Ok);
     msgBox.setIcon(QMessageBox::Question);
@@ -619,12 +619,12 @@ void Configuration::on_pushButton_Supprimer_operations_clicked()
 
         if (!query.isActive())
         {
-            qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() <<
+            qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() <<
                 query.driver();
         }
         else
         {
-            qDebug() << "suppression terminée";
+            qDebug() << "delete finished";
         }
         QSqlQueryModel *model4 = new QSqlQueryModel;
         model4->setQuery("SELECT id, designation FROM taches");
@@ -656,11 +656,11 @@ void Configuration::on_pushButton_enregistrer_operations_clicked()
 
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
     }
     else
     {
-        qDebug() << "enregistrement terminé";
+        qDebug() << "record finished";
     }
 
     QSqlQueryModel *model4 = new QSqlQueryModel;
@@ -683,7 +683,7 @@ void Configuration::on_tableView_taches_clicked(const QModelIndex&index)
 }
 
 void Configuration::on_pushButton_mise_a_jour_clicked()
-{   // Mise à jour d'une ancienne base de données vers la version 1.06
+{   // Update an old database to version 1.06
     QString      fileName(getSqlFileName());
     QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
 
@@ -693,12 +693,12 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
     db.setDatabaseName(fileName);
     if (!db.open())
     {
-        qDebug() << "connection database erreur " << fileName;
+        qDebug() << "database connection error " << fileName;
     }
     else
     {
         qDebug() << "database open " << fileName;
-        ui->plainTextMessages->insertPlainText("Base de données ouverte :" + fileName + "\n");
+        ui->plainTextMessages->insertPlainText("Database opened:" + fileName + "\n");
     }
 
     QString queryStr;
@@ -706,7 +706,7 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
     if (!file.open(QFile::ReadOnly | QFile::Text))
     {
         QMessageBox msgBox;
-        msgBox.setText("ERREUR D'ÉCRITURE");
+        msgBox.setText("WRITE ERROR");
         return;
     }
     else
@@ -722,21 +722,21 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
 
 
 
-    ui->plainTextMessages->insertPlainText("Données importée dans la nouvelle base \n");
-    //Vérifier si le driver SQL supporte les Transactions
+    ui->plainTextMessages->insertPlainText("Data imported into the new database \n");
+    //Check if the SQL driver supports Transactions
     if (db.driver()->hasFeature(QSqlDriver::Transactions))
     {
-        //Remplace les commentaires, tabulations et nouvelles lignes avec des espaces
+        //Replace comments, tabs and newlines with spaces
         queryStr =
             queryStr.replace(QRegularExpression("(\\/\\*(.|\\n)*?\\*\\/|^--.*\\n|\\t|\\n)",
                                                 QRegularExpression::CaseInsensitiveOption |
                                                 QRegularExpression::MultilineOption), " ");
-        //Supprimer les espaces inutiles
+        //Remove unnecessary spaces
         queryStr = queryStr.trimmed();
 
-        //Extraction des requêtes
+        //Extract queries
         QStringList qList = queryStr.split(';', QString::SkipEmptyParts);
-        //Initialise les expressions pour détecter les requêts spéciales(`begin transaction` and `commit`).
+        //Initialize expressions to detect special queries (`begin transaction` and `commit`).
         QRegularExpression re_transaction("\\bbegin.transaction.*", QRegularExpression::CaseInsensitiveOption);
         QRegularExpression re_commit("\\bcommit.*", QRegularExpression::CaseInsensitiveOption);
 
@@ -745,26 +745,26 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
         {
             db.transaction();
         }
-        //Executer chaque requête individuellement
+        //Execute each query individually
 
         foreach(const QString &s, qList)
         {
-            if (re_transaction.match(s).hasMatch())        //<== detection des requêtes spéciales
+            if (re_transaction.match(s).hasMatch())        //<== detect special queries
             {
                 db.transaction();
             }
-            else if (re_commit.match(s).hasMatch())        //<== detection des requêtes spéciales
+            else if (re_commit.match(s).hasMatch())        //<== detect special queries
             {
                 db.commit();
             }
             else
             {
-                query.exec(s);                             //<== executer les requêtes normales
+                query.exec(s);                             //<== execute normal queries
                 if (query.lastError().type() != QSqlError::NoError)
                 {
-                    qDebug() << "erreur 292 " << query.lastError().text() << query.lastQuery();
+                    qDebug() << "error 292 " << query.lastError().text() << query.lastQuery();
 
-                    db.rollback();                         //<== rollback la transaction s'il y a un probême
+                    db.rollback();                         //<== rollback the transaction if there is a problem
                     ui->plainTextMessages->insertPlainText(query.lastError().databaseText() + " \n");
                 }
                 else
@@ -773,7 +773,7 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
                 }
             }
         }
-        ui->plainTextMessages->insertPlainText("Mise à jour de la base de données terminée \n");
+        ui->plainTextMessages->insertPlainText("Database update finished \n");
 
         if (!isStartedWithTransaction)
         {
@@ -781,8 +781,8 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
         }
     }
     else
-    {         //si le driver sql ne support pas les transactions
-              //...il est nécessaire de supprimer les requêtes spéciales(`begin transaction` and `commit`)
+    {         //if the sql driver does not support transactions
+              //...it is necessary to delete special queries (`begin transaction` and `commit`)
         queryStr =
             queryStr.replace(QRegularExpression(
                                  "(\\bbegin.transaction.*;|\\bcommit.*;|\\/\\*(.|\\n)*?\\*\\/|^--.*\\n|\\t|\\n)",
@@ -790,7 +790,7 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
                                  QRegularExpression::MultilineOption), " ");
         queryStr = queryStr.trimmed();
 
-        //Executer chaque requête individuellement
+        //Execute each query individually
         QStringList qList = queryStr.split(';', QString::SkipEmptyParts);
         foreach(const QString &s, qList)
         {
@@ -802,7 +802,7 @@ void Configuration::on_pushButton_mise_a_jour_clicked()
             else
             {
             }
-            ui->plainTextMessages->insertPlainText("Mise à jour de la base de données terminée \n");
+            ui->plainTextMessages->insertPlainText("Database update finished \n");
         }
     }
 }

--- a/dialogs/configuration.h
+++ b/dialogs/configuration.h
@@ -23,14 +23,14 @@ public:
     void createConnection(QString fileName);
     void init_base();
 
-    void setXmlFilName(const QString&xmlFileName)
+    void setXmlFileName(const QString&xmlFileName)
     {
-        m_xmlFilName = xmlFileName;
+        m_xmlFileName = xmlFileName;
     }
 
-    QString getXmlFilName()
+    QString getXmlFileName()
     {
-        return m_xmlFilName;
+        return m_xmlFileName;
     }
 
     void setSqlFileName(const QString&sqlFileName)
@@ -43,7 +43,7 @@ public:
         return m_sqlFileName;
     }
 
-    void enregistrerDataBase();
+    void saveDataBase();
 
 private slots:
     void on_pushButton_changeDataBase_clicked();
@@ -54,27 +54,27 @@ private slots:
 
     void on_pushButton_export_clicked();
 
-    void on_pushButton_Modifier_operations_clicked();
+    void on_pushButton_Modify_operations_clicked();
 
-    void on_pushButton_Supprimer_operations_clicked();
+    void on_pushButton_Delete_operations_clicked();
 
-    void on_pushButton_Nouveau_operations_clicked();
+    void on_pushButton_New_operations_clicked();
 
-    void on_pushButton_enregistrer_operations_clicked();
+    void on_pushButton_save_operations_clicked();
 
-    void on_tableView_taches_clicked(const QModelIndex&index);
+    void on_tableView_tasks_clicked(const QModelIndex&index);
 
-    void on_pushButton_fermer_clicked();
+    void on_pushButton_close_clicked();
 
 
-    void on_pushButton_mise_a_jour_clicked();
+    void on_pushButton_update_clicked();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
 
 private:
     Ui::Configuration *ui;
-    QString m_xmlFilName;
+    QString m_xmlFileName;
     QString m_sqlFileName;
 };
 

--- a/dialogs/configuration.ui
+++ b/dialogs/configuration.ui
@@ -56,7 +56,7 @@
     <item row="1" column="1">
      <widget class="QLineEdit" name="lineEdit_config_nom_base">
       <property name="toolTip">
-       <string>Modifié uniquement en changeant de base de donnée active</string>
+       <string>Modified only by changing the active database</string>
       </property>
       <property name="text">
        <string>jardin.sqli</string>
@@ -85,7 +85,7 @@
     </font>
    </property>
    <property name="text">
-    <string>Paramétrage des types d'observations</string>
+    <string>Observation Types Settings</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -155,7 +155,7 @@
      </font>
     </property>
     <property name="text">
-     <string>Liste des types d'observations</string>
+    <string>List of Observation Types</string>
     </property>
    </widget>
    <widget class="QTableView" name="tableView_taches">
@@ -205,7 +205,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Désignation</string>
+        <string>Designation</string>
        </property>
       </widget>
      </item>
@@ -215,7 +215,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_11">
        <property name="text">
-        <string>Enregistrement N°</string>
+        <string>Record N°</string>
        </property>
       </widget>
      </item>
@@ -255,7 +255,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Enregistrer modifications</string>
+          <string>Save Changes</string>
          </property>
         </widget>
        </item>
@@ -274,7 +274,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Supprimer</string>
+          <string>Delete</string>
          </property>
         </widget>
        </item>
@@ -293,7 +293,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Fiche vierge</string>
+          <string>New Record</string>
          </property>
         </widget>
        </item>
@@ -312,7 +312,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Enregistrer nouvelle fiche</string>
+          <string>Save New Record</string>
          </property>
         </widget>
        </item>
@@ -358,28 +358,28 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>Choisir la base de données active</string>
+         <string>Choose Active Database</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="pushButton_mise_a_jour">
         <property name="text">
-         <string>Mise à jour de la base de données vers v 1.06</string>
+         <string>Update Database to v 1.06</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="pushButton_NewdatabaseFull">
         <property name="text">
-         <string>Créer une nouvelle base de données pré-remplie</string>
+         <string>Create New Pre-filled Database</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="pushButton_import">
         <property name="text">
-         <string>Créer une base de données et importer les données</string>
+         <string>Create Database and Import Data</string>
         </property>
        </widget>
       </item>
@@ -389,7 +389,7 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>Exporter la base de données</string>
+         <string>Export Database</string>
         </property>
        </widget>
       </item>
@@ -424,24 +424,24 @@
     <bool>true</bool>
    </property>
    <property name="plainText">
-    <string>Le fichier XML contient les données de configuration du plan du terrain avec les parcelles, les matériels et les plantations.
-Le fichier de la base de données (.sqli) qui est lié au fichier de configuration  contient :
-- les fiches cultures (associées aux parcelles)
-- les fiches plantes
-- les fiches espèces 
-- les fiches des familles de plantes
+    <string>The XML file contains the configuration data of the land plan with plots, equipment and plantations.
+The database file (.sqli) which is linked to the configuration file contains:
+- crop sheets (associated with plots)
+- plant sheets
+- species sheets
+- plant family sheets
 
-Choisir la base de données active:
-Vous pouvez choisir la base de données .sqli qui sera active, puis sauvegarder le nom de cette base dans le fichier de configuration .xml en sauvegardant le fichier de configuration .xml
- 
-Création d'une nouvelle base de données:
-Vous pouvez soit créer : 
-- une base de donnée avec uniquement les tables sans données, 
-- une base de données avec les tables especes - familles -  taches préremplies, 
--  une nouvelle base en important un fichier texte de sauvegarde de type  .sql qui comprend les tables et les données.
+Choose the active database:
+You can choose the .sqli database that will be active, then save the name of this database in the .xml configuration file by saving the .xml configuration file.
 
-Export de la base de donnée active:
-La base de données est sauvegardée sous un nouveau nom dans un fichier texte de requête sql de type .sql. ce fichier peut être importé en tant que nouvele base de données.</string>
+Creating a new database:
+You can either create:
+- a database with only tables without data,
+- a database with pre-filled species - families - tasks tables,
+- a new database by importing a backup text file of type .sql which includes tables and data.
+
+Export of the active database:
+The database is saved under a new name in a text file of sql query of type .sql. this file can be imported as a new database.</string>
    </property>
   </widget>
   <widget class="QLabel" name="label">
@@ -461,7 +461,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
     </font>
    </property>
    <property name="text">
-    <string>Aide </string>
+    <string>Help</string>
    </property>
   </widget>
   <widget class="QPushButton" name="pushButton_fermer">
@@ -480,7 +480,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
     </font>
    </property>
    <property name="text">
-    <string>Fermer </string>
+    <string>Close</string>
    </property>
    <property name="icon">
     <iconset resource="../libreJardin.qrc">
@@ -537,7 +537,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
         </size>
        </property>
        <property name="text">
-        <string>Désignation</string>
+        <string>Designation</string>
        </property>
       </widget>
      </item>
@@ -547,7 +547,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
      <item row="0" column="0">
       <widget class="QLabel" name="label_12">
        <property name="text">
-        <string>Enregistrement N°</string>
+        <string>Record N°</string>
        </property>
       </widget>
      </item>
@@ -587,7 +587,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
           </size>
          </property>
          <property name="text">
-          <string>Enregistrer modifications</string>
+          <string>Save Changes</string>
          </property>
         </widget>
        </item>
@@ -606,7 +606,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
           </size>
          </property>
          <property name="text">
-          <string>Supprimer</string>
+          <string>Delete</string>
          </property>
         </widget>
        </item>
@@ -625,7 +625,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
           </size>
          </property>
          <property name="text">
-          <string>Fiche vierge</string>
+          <string>New Record</string>
          </property>
         </widget>
        </item>
@@ -644,7 +644,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
           </size>
          </property>
          <property name="text">
-          <string>Enregistrer nouvelle fiche</string>
+          <string>Save New Record</string>
          </property>
         </widget>
        </item>
@@ -670,7 +670,7 @@ La base de données est sauvegardée sous un nouveau nom dans un fichier texte d
     </font>
    </property>
    <property name="text">
-    <string>Paramétrage des unités</string>
+    <string>Units Settings</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/dialogs/cultures.cpp
+++ b/dialogs/cultures.cpp
@@ -54,34 +54,34 @@ Cultures::Cultures(const int&IdItem, const int&IdCulture, QWidget *parent) :
 {
     // translator
     QTranslator translator;
-    QString     fichier = ":/translations/open-jardin_" + util::getLocale();
+    QString     fileContent = ":/translations/open-jardin_" + util::getLocale();
 
-    translator.load(fichier);
+    translator.load(fileContent);
     qApp->installTranslator(&translator);
 
     ui->setupUi(this);
-    setIdItem(IdItem);     // id de la parcelle
+    setIdItem(IdItem);     // id of the plot
     setIdCulture(IdCulture);
     ui->lineEditIdParcelle->setText(QString::number(m_idItem));
     ui->lineEdit_id_cultures->setText(QString::number(m_idCulture));
 
-    // mise à la date du jour du dateEdit de la fiche
-    QDate dateDuJour;
-    dateDuJour = dateDuJour.currentDate();
-    ui->dateEdit->setDate(dateDuJour);
-    ui->dateEdit_tache->setDate(dateDuJour);
-    // mise à jour date de récolte selon durée prévisionnelle
+    // set the dateEdit of the sheet to today's date
+    QDate currentDate;
+    currentDate = currentDate.currentDate();
+    ui->dateEdit->setDate(currentDate);
+    ui->dateEdit_tache->setDate(currentDate);
+    // update harvest date according to estimated duration
     QString str1  = ui->dateEdit->date().toString("yyyy.MM.dd");
     QDate   dateS = QDate::fromString(str1, "yyyy.MM.dd");
     QDate   dateR = dateS.addDays(ui->lineEdit_duree->text().toInt());
     ui->dateEdit_fin_culture->setDate(dateR);
 
-    //remplissage combobox espèces type de plantes
+    //fill combobox species plant type
     QSqlQueryModel *modelM = new QSqlQueryModel;
     modelM->setQuery("SELECT designation,type_lune FROM plantes ORDER BY designation ASC");
     ui->comboBox_plante->setModel(modelM);
 
-    //remplissage combobox type taches
+    //fill combobox task type
     QSqlQueryModel *modelTache = new QSqlQueryModel;
     modelTache->setQuery("SELECT designation FROM taches ORDER BY designation ASC");
     ui->comboBox_type_tache->setModel(modelTache);
@@ -97,7 +97,7 @@ void Cultures::init_models(int idculture)
                             m_idItem));
         model->setHeaderData(0, Qt::Vertical, QObject::tr("id"));
         model->setHeaderData(1, Qt::Vertical, QObject::tr("designation"));
-        model->setHeaderData(3, Qt::Vertical, QObject::tr("parcelle"));
+        model->setHeaderData(3, Qt::Vertical, QObject::tr("plot"));
         ui->tableViewCultures->setModel(model);
 
         QSqlQueryModel *modelObs = new QSqlQueryModel;
@@ -115,7 +115,7 @@ void Cultures::init_models(int idculture)
                             idculture));
         model->setHeaderData(0, Qt::Vertical, QObject::tr("id"));
         model->setHeaderData(1, Qt::Vertical, QObject::tr("designation"));
-        model->setHeaderData(3, Qt::Vertical, QObject::tr("parcelle"));
+        model->setHeaderData(3, Qt::Vertical, QObject::tr("plot"));
         ui->tableViewCultures->setModel(model);
         QSqlQueryModel *modelObs = new QSqlQueryModel;
         modelObs->setQuery("SELECT id, designation, date,type , commentaires,id_culture FROM observations where id_culture= " + QString::number(
@@ -139,15 +139,15 @@ void Cultures::init_models(int idculture)
         QDate date2 = QDate::fromString(str6, "yyyy.MM.dd");
         ui->dateEdit_fin_culture->setDate(date2);
         ui->lineEdit_duree->setText(str5);
-        //selection plante dans combobox
+        //select plant in combobox
         QSqlQuery query;
-        QString   resultat;
+        QString   result;
         query.exec(QString("select designation from plantes where id =" + str2));
         if (query.first())
         {
-            resultat = query.value(0).toString();
+            result = query.value(0).toString();
 
-            ui->comboBox_plante->setCurrentIndex(ui->comboBox_plante->findText(resultat));
+            ui->comboBox_plante->setCurrentIndex(ui->comboBox_plante->findText(result));
         }
         ui->comboBox_etat_culture->setCurrentIndex(str4.toInt() - 1);
         ui->plainTextEdit_commentaires->setPlainText(str3);
@@ -160,7 +160,7 @@ Cultures::~Cultures()
 }
 
 void Cultures::on_pushButton_nouvelleOperation_clicked()
-{   //création d'une fiche de culture vierge
+{   //create a blank crop record
     ui->lineEditDesignation->setText("");
     ui->plainTextEdit_commentaires->setPlainText("");
     ui->comboBox_plante->setCurrentIndex(0);
@@ -168,24 +168,24 @@ void Cultures::on_pushButton_nouvelleOperation_clicked()
 }
 
 void Cultures::on_pushButton_validerData_clicked()
-{   //ajouter un enregistrement de la table "cultures" valider les données et enregistrer dans la base
+{   //add a record to the "cultures" table, validate the data and save to the database
     QSqlQuery query;
-    QString   nom_plante = util::apos(ui->comboBox_plante->currentText());
-    QString   id_plante;
+    QString   plant_name = util::apos(ui->comboBox_plante->currentText());
+    QString   id_plant;
 
-    query.exec(QString("select id from plantes where designation ='" + nom_plante + "'"));
+    query.exec(QString("select id from plantes where designation ='" + plant_name + "'"));
     if (query.first())
     {
-        id_plante = query.value(0).toString();
+        id_plant = query.value(0).toString();
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     QString str1 = ui->dateEdit->date().toString("yyyy.MM.dd");
-    QString str2 = id_plante;
+    QString str2 = id_plant;
     QString str3 = util::apos(ui->plainTextEdit_commentaires->document()->toPlainText());
     QString str4 = QString::number(ui->comboBox_etat_culture->currentIndex() + 1);
     QString str5 = ui->lineEdit_duree->text();
@@ -197,20 +197,20 @@ void Cultures::on_pushButton_validerData_clicked()
     query.exec(str);
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     else
     {
-        qDebug() << "enregistrement terminé";
+        qDebug() << "record finished";
     }
     QSqlQueryModel *model = new QSqlQueryModel;
     model->setQuery("SELECT id, designation, parcelle, date_semis, type_plante , commentaires,etat,duree,date_recolte FROM cultures WHERE parcelle=" + QString::number(
                         m_idItem));
     model->setHeaderData(0, Qt::Vertical, QObject::tr("id"));
     model->setHeaderData(1, Qt::Vertical, QObject::tr("designation"));
-    model->setHeaderData(3, Qt::Vertical, QObject::tr("parcelle"));
+    model->setHeaderData(3, Qt::Vertical, QObject::tr("plot"));
     ui->tableViewCultures->setModel(model);
 }
 
@@ -232,20 +232,20 @@ void Cultures::on_tableViewCultures_clicked(const QModelIndex&index)
     QDate date2 = QDate::fromString(str6, "yyyy.MM.dd");
     ui->dateEdit_fin_culture->setDate(date2);
     ui->lineEdit_duree->setText(str5);
-    //selection plante dans combobox
+    //select plant in combobox
     QSqlQuery query;
-    QString   resultat;
+    QString   result;
     query.exec(QString("select designation from plantes where id =" + str2));
     if (query.first())
     {
-        resultat = query.value(0).toString();
-        ui->comboBox_plante->setCurrentIndex(ui->comboBox_plante->findText(resultat));
+        result = query.value(0).toString();
+        ui->comboBox_plante->setCurrentIndex(ui->comboBox_plante->findText(result));
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     ui->comboBox_etat_culture->setCurrentIndex(str4.toInt() - 1);
     ui->plainTextEdit_commentaires->setPlainText(str3);
@@ -255,122 +255,122 @@ void Cultures::on_tableViewCultures_clicked(const QModelIndex&index)
 void Cultures::on_comboBox_plante_currentIndexChanged(const QString&arg1)
 {
     QSqlQuery query;
-    QString   id_plante;
-    QString   resultat;
-    QString   id_espece;
-    QString   design_espece;
-    QString   id_famille;
-    QString   design_famille;
+    QString   id_plant;
+    QString   result;
+    QString   id_species;
+    QString   design_species;
+    QString   id_family;
+    QString   design_family;
 
     query.exec(QString("select id from plantes where designation ='" + util::apos(arg1) + "'"));
     if (query.first())
     {
-        id_plante = query.value(0).toString();
-        ui->lineEditTypeLune->clear(); //effacer
-        query.exec(QString("select type_lune from plantes where id=" + id_plante));
+        id_plant = query.value(0).toString();
+        ui->lineEditTypeLune->clear(); //clear
+        query.exec(QString("select type_lune from plantes where id=" + id_plant));
         if (query.first())
         {
-            resultat = query.value(0).toString();
+            result = query.value(0).toString();
         }
         else
         {
-            qWarning("ne peut récupérer la valeur type lune");
+            qWarning("cannot retrieve moon type value");
         }
 
-        ui->lineEditTypeLune->setText(resultat);
+        ui->lineEditTypeLune->setText(result);
 
-        query.exec(QString("select espece from plantes where id=" + id_plante));
+        query.exec(QString("select espece from plantes where id=" + id_plant));
         if (query.first())
         {
-            id_espece = query.value(0).toString();
+            id_species = query.value(0).toString();
         }
         else
         {
-            qWarning("ne peut récupérer la valeur espece");
+            qWarning("cannot retrieve species value");
         }
 
-        query.exec(QString("select designation from especes where id=" + id_espece));
+        query.exec(QString("select designation from especes where id=" + id_species));
         if (query.first())
         {
-            design_espece = query.value(0).toString();
+            design_species = query.value(0).toString();
         }
         else
         {
-            qWarning("ne peut récupérer la valeur designation espece");
+            qWarning("cannot retrieve species designation value");
         }
 
-        query.exec(QString("select famille from especes where id=" + id_espece));
+        query.exec(QString("select famille from especes where id=" + id_species));
         if (query.first())
         {
-            id_famille = query.value(0).toString();
+            id_family = query.value(0).toString();
         }
         else
         {
-            qWarning("ne peut récupérer la valeur famille espece");
+            qWarning("cannot retrieve species family value");
         }
 
-        query.exec(QString("select designation from familles where id=" + id_famille));
+        query.exec(QString("select designation from familles where id=" + id_family));
         if (query.first())
         {
-            design_famille = query.value(0).toString();
+            design_family = query.value(0).toString();
         }
         else
         {
-            qWarning("ne peut récupérer la valeur designation famille");
+            qWarning("cannot retrieve family designation value");
         }
 
-        ui->lineEdit_Fiche_culture_espece->setText(design_espece);
-        ui->lineEdit_Fiche_culture_famille->setText(design_famille);
+        ui->lineEdit_Fiche_culture_espece->setText(design_species);
+        ui->lineEdit_Fiche_culture_famille->setText(design_family);
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
     }
 }
 
 void Cultures::on_lineEditTypeLune_textChanged(const QString&arg1)
 {
     QSqlQuery query;
-    QString   resultat;
+    QString   result;
     int       row = arg1.toInt();
 
-    ui->lineEditDesign_Lune->clear(); //effacer
+    ui->lineEditDesign_Lune->clear(); //clear
     query.exec(QString("select designation from lune where id=" + QString::number(row)));
     if (query.first())
     {
-        resultat = query.value(0).toString();
+        result = query.value(0).toString();
     }
 
 
-    ui->lineEditDesign_Lune->setText(resultat);
+    ui->lineEditDesign_Lune->setText(result);
 
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
     }
 }
 
 void Cultures::on_pushButton_modifier_clicked()
 {
-    //enregister la fiche modifiée
+    //save the modified sheet
     QSqlQuery query;
-    QString   nom_plante = util::apos(ui->comboBox_plante->currentText());
-    QString   id_plante;
+    QString   plant_name = util::apos(ui->comboBox_plante->currentText());
+    QString   id_plant;
 
-    query.exec(QString("select id from plantes where designation ='" + nom_plante + "'"));
+    query.exec(QString("select id from plantes where designation ='" + plant_name + "'"));
     if (query.first())
     {
-        id_plante = query.value(0).toString();
+        id_plant = query.value(0).toString();
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     QString str1 = ui->dateEdit->date().toString("yyyy.MM.dd");
     QString str  = util::apos(ui->lineEditDesignation->text());
-    QString str2 = id_plante;
+    QString str2 = id_plant;
     QString str3 = util::apos(ui->plainTextEdit_commentaires->document()->toPlainText());
     QString str4 = ui->lineEdit_id_cultures->text();
     QString str5 = ui->lineEditIdParcelle->text();
@@ -387,13 +387,13 @@ void Cultures::on_pushButton_modifier_clicked()
 
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     else
     {
-        qDebug() << "enregistrement terminé";
+        qDebug() << "record finished";
     }
 
     QSqlQueryModel *model = new QSqlQueryModel;
@@ -401,35 +401,35 @@ void Cultures::on_pushButton_modifier_clicked()
                         m_idItem));
     model->setHeaderData(0, Qt::Vertical, QObject::tr("id"));
     model->setHeaderData(1, Qt::Vertical, QObject::tr("designation"));
-    model->setHeaderData(3, Qt::Vertical, QObject::tr("parcelle"));
+    model->setHeaderData(3, Qt::Vertical, QObject::tr("plot"));
     ui->tableViewCultures->setModel(model);
 }
 
-/*************** base de données des taches et observations*************************/
+/*************** database of tasks and observations*************************/
 
 void Cultures::on_pushButton_modifier_tache_clicked()
 {
-    //enregister la fiche modifiée
+    //save the modified sheet
     QSqlQuery query;
-    QString   nom_type_tache = ui->comboBox_type_tache->currentText();
-    QString   id_type_tache;
+    QString   task_type_name = ui->comboBox_type_tache->currentText();
+    QString   id_task_type;
 
-    query.exec(QString("select id from taches where designation ='" + nom_type_tache + "'"));
+    query.exec(QString("select id from taches where designation ='" + task_type_name + "'"));
     if (query.first())
     {
-        id_type_tache = query.value(0).toString();
-        qDebug() << nom_type_tache << " id " << id_type_tache;
+        id_task_type = query.value(0).toString();
+        qDebug() << task_type_name << " id " << id_task_type;
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
 
-    QString str1     = ui->dateEdit_tache->date().toString("yyyy.MM.dd");                            //date tache
-    QString str      = util::apos(ui->lineEdit_designation_tache->text());                           //designation tache
-    QString str2     = id_type_tache;                                                                // id du type de tache
+    QString str1     = ui->dateEdit_tache->date().toString("yyyy.MM.dd");                            //task date
+    QString str      = util::apos(ui->lineEdit_designation_tache->text());                           //task designation
+    QString str2     = id_task_type;                                                                // id of task type
     QString str3     = util::apos(ui->plainTextEdit_observations_taches->document()->toPlainText()); //observations
     QString str4     = ui->lineEdit_id_tache->text();                                                //id
     QString str5     = ui->lineEdit_id_cultures->text();                                             // id culture
@@ -439,13 +439,13 @@ void Cultures::on_pushButton_modifier_tache_clicked()
     query.exec(strQuery);
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     else
     {
-        qDebug() << "enregistrement terminé";
+        qDebug() << "record finished";
     }
     QSqlQueryModel *modelObs = new QSqlQueryModel;
     modelObs->setQuery("SELECT id, designation, date,type , commentaires,id_culture FROM observations where id_culture= " + str5);
@@ -457,26 +457,26 @@ void Cultures::on_pushButton_modifier_tache_clicked()
 
 void Cultures::on_pushButton_creer_tache_clicked()
 {
-    //ajouter un enregistrement de la table "OBSERVATIONS" valider les données et enregistrer dans la base
+    //add a record to the "OBSERVATIONS" table, validate the data and save to the database
 
     QSqlQuery query;
-    QString   nom_type_tache = ui->comboBox_type_tache->currentText();
-    QString   id_type_tache;
+    QString   task_type_name = ui->comboBox_type_tache->currentText();
+    QString   id_task_type;
 
-    query.exec(QString("select id from taches where designation ='" + nom_type_tache + "'"));
+    query.exec(QString("select id from taches where designation ='" + task_type_name + "'"));
     if (query.first())
     {
-        id_type_tache = query.value(0).toString();
+        id_task_type = query.value(0).toString();
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
-    QString str1 = ui->dateEdit_tache->date().toString("yyyy.MM.dd");                            //date tache
-    QString str  = util::apos(ui->lineEdit_designation_tache->text());                           //designation tache
-    QString str2 = id_type_tache;                                                                // id du type de tache
+    QString str1 = ui->dateEdit_tache->date().toString("yyyy.MM.dd");                            //task date
+    QString str  = util::apos(ui->lineEdit_designation_tache->text());                           //task designation
+    QString str2 = id_task_type;                                                                // id of task type
     QString str3 = util::apos(ui->plainTextEdit_observations_taches->document()->toPlainText()); //observations
     QString str4 = ui->lineEdit_id_tache->text();                                                //id
     QString str5 = ui->lineEdit_id_cultures->text();                                             // id culture
@@ -487,13 +487,13 @@ void Cultures::on_pushButton_creer_tache_clicked()
 
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
-        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        QMessageBox::information(this, tr("Recording error"),
+                                 tr("Please check that all fields are filled in correctly"));
     }
     else
     {
-        qDebug() << "enregistrement terminé";
+        qDebug() << "record finished";
     }
     QSqlQueryModel *modelObs = new QSqlQueryModel;
     modelObs->setQuery("SELECT id, designation, date,type , commentaires,id_culture FROM observations where id_culture= " + str5);
@@ -518,18 +518,18 @@ void Cultures::on_tableView_taches_clicked(const QModelIndex&index)
     QDate date = QDate::fromString(str1, "yyyy.MM.dd");
     ui->dateEdit_tache->setDate(date);
 
-    //calage combo_type_tache sur valeur id
+    //set combo_type_tache to id value
     QSqlQuery query;
-    QString   resultat;
+    QString   result;
     query.exec(QString("select designation from taches where id =" + str2));
     if (query.first())
     {
-        resultat = query.value(0).toString();
-        ui->comboBox_type_tache->setCurrentIndex(ui->comboBox_type_tache->findText(resultat));
+        result = query.value(0).toString();
+        ui->comboBox_type_tache->setCurrentIndex(ui->comboBox_type_tache->findText(result));
     }
     else
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
     }
 }
 
@@ -544,11 +544,11 @@ void Cultures::on_lineEdit_id_cultures_textChanged(const QString&arg1)
     ui->tableView_taches->setModel(modelObs);
 }
 
-/*******************************IMPRESSION FICHE***********************/
+/*******************************PRINT SHEET***********************/
 
 void Cultures::on_pushButton_print_fiche_clicked()
 {
-    QString   titre   = " FICHE DE CULTURE ";
+    QString   title   = " CROP SHEET ";
     QPrinter *printer = new QPrinter(QPrinter::HighResolution);
 
     printer->setPaperSize(QPrinter::A4);
@@ -561,49 +561,49 @@ void Cultures::on_pushButton_print_fiche_clicked()
     if (printDialog.exec() == 1)
     {
         QTextBrowser *editor = new QTextBrowser;
-        //creation de formats d'écriture
+        //create writing formats
         QTextCharFormat NormalFormat;
 
         QTextCharFormat ItalicFormat;
         ItalicFormat.setFontItalic(true);
 
-        //On insere la date et l'heure actuelle au début de la premiere page
+        //Insert the current date and time at the beginning of the first page
         QDate date;
         QTime time;
         date = date.currentDate();
         time = time.currentTime();
-        QString modif = "Fait le : " + date.toString("dddd dd MMMM yyyy") + " à " + time.toString();
+        QString modif = "Done on : " + date.toString("dddd dd MMMM yyyy") + " at " + time.toString();
 
-        //changement du format d'ecriture
+        //change writing format
         editor->setCurrentCharFormat(ItalicFormat);
         editor->setAlignment(Qt::AlignLeft);
 
-        //ajout de la QString a l'endroit du curseur
+        //add the QString at the cursor position
         editor->append(modif);
         editor->setCurrentCharFormat(NormalFormat);
 
-        //on insere le titre du tableau
-        QTextCharFormat format_gros_titre;
-        format_gros_titre.setFontPointSize(20);
-        format_gros_titre.setFontWeight(QFont::Bold);
-        format_gros_titre.setVerticalAlignment(QTextCharFormat::AlignMiddle);
-        //  format_gros_titre.setUnderlineStyle(QTextCharFormat::SingleUnderline);
+        //insert the table title
+        QTextCharFormat format_large_title;
+        format_large_title.setFontPointSize(20);
+        format_large_title.setFontWeight(QFont::Bold);
+        format_large_title.setVerticalAlignment(QTextCharFormat::AlignMiddle);
+        //  format_large_title.setUnderlineStyle(QTextCharFormat::SingleUnderline);
 
-        QString title = QString::fromUtf8(titre.toStdString().c_str());
-        editor->setCurrentCharFormat(format_gros_titre);
+        QString titleStr = QString::fromUtf8(title.toStdString().c_str());
+        editor->setCurrentCharFormat(format_large_title);
         editor->setAlignment(Qt::AlignCenter);
 
-        editor->append(title);
+        editor->append(titleStr);
 
-        QString parcelle = "Parcelle N° : " + ui->lineEditIdParcelle->text() + " \n";
-        editor->append(parcelle);
+        QString plot = "Plot N° : " + ui->lineEditIdParcelle->text() + " \n";
+        editor->append(plot);
 
         editor->setCurrentCharFormat(NormalFormat);
-        //on crée un curseur a l'endroit du curseur actuel
+        //create a cursor at the current cursor position
         QTextCursor cursor = editor->textCursor();
         cursor.beginEditBlock();
 
-        //Creation du format du tableau qui sera imprimer
+        //Creation of the format of the table to be printed
         QTextTableFormat tableFormat;
         tableFormat.setAlignment(Qt::AlignHCenter);
         tableFormat.setAlignment(Qt::AlignLeft);
@@ -611,9 +611,9 @@ void Cultures::on_pushButton_print_fiche_clicked()
         tableFormat.setCellPadding(1);
         tableFormat.setCellSpacing(1);
 
-        //Creation du tableau qui sera imprimé avec le nombre de colonne
-        //et de ligne que contient le tableau mis en parametre
-        QTextTable *tableau = cursor.insertTable(ui->tableViewCultures->model()->rowCount() + 3,
+        //Creation of the table to be printed with the number of columns
+        //and rows contained in the table passed as parameter
+        QTextTable *table = cursor.insertTable(ui->tableViewCultures->model()->rowCount() + 3,
                                                  ui->tableViewCultures->model()->columnCount(), tableFormat);
 
         QTextFrame *     frame       = cursor.currentFrame();
@@ -621,66 +621,66 @@ void Cultures::on_pushButton_print_fiche_clicked()
         frameFormat.setBorder(0);
         frame->setFrameFormat(frameFormat);
 
-        //Format des HEADER du tableau
-        QTextCharFormat format_entete_tableau;
-        format_entete_tableau.setFontPointSize(10);
-        format_entete_tableau.setFontWeight(QFont::Bold);
+        //Format of the table HEADERS
+        QTextCharFormat format_table_header;
+        format_table_header.setFontPointSize(10);
+        format_table_header.setFontWeight(QFont::Bold);
 
-        //Format du texte des cellules du tableau
-        QTextCharFormat format_cellule;
-        format_cellule.setFontPointSize(10);
+        //Format of the text in the table cells
+        QTextCharFormat format_cell;
+        format_cell.setFontPointSize(10);
 
 
         QTextTableCell cell;
         QTextCursor    cellCursor;
-        //on ecrit les HEADERS du tableaux dans le tableau a imprimer
-        for (int col = 0; col < tableau->columns(); col++)
+        //write the table HEADERS in the table to be printed
+        for (int col = 0; col < table->columns(); col++)
         {
-            QString texte = ui->tableViewCultures->model()->headerData(col, Qt::Horizontal).toString();
-            cell       = tableau->cellAt(0, col);
+            QString text = ui->tableViewCultures->model()->headerData(col, Qt::Horizontal).toString();
+            cell       = table->cellAt(0, col);
             cellCursor = cell.firstCursorPosition();
-            cellCursor.insertText(texte, format_cellule);
+            cellCursor.insertText(text, format_cell);
         }
 
-        for (int row = 1; row < tableau->rows() - 2; row++)
+        for (int row = 1; row < table->rows() - 2; row++)
         {
-            for (int col = 0; col < tableau->columns(); col++)
+            for (int col = 0; col < table->columns(); col++)
             {
-                QString texte1 = "";
+                QString text1 = "";
                 if (col == 1 || col == 2)
                 {
-                    texte1 = ui->tableViewCultures->model()->index(row - 1, col).data().toString();
+                    text1 = ui->tableViewCultures->model()->index(row - 1, col).data().toString();
                 }
                 else
                 {
-                    texte1 = QString::number(ui->tableViewCultures->model()->index(row - 1, col).data().toDouble());
+                    text1 = QString::number(ui->tableViewCultures->model()->index(row - 1, col).data().toDouble());
                 }
                 if (col == 3)
                 {
-                    texte1 = ui->tableViewCultures->model()->index(row - 1, col).data().toDate().toString("dd/MM/yyyy");
+                    text1 = ui->tableViewCultures->model()->index(row - 1, col).data().toDate().toString("dd/MM/yyyy");
                 }
                 if (col == 5)
                 {
-                    texte1 = ui->tableViewCultures->model()->index(row - 1, col).data().toString();
+                    text1 = ui->tableViewCultures->model()->index(row - 1, col).data().toString();
                 }
-                cell       = tableau->cellAt(row, col);
+                cell       = table->cellAt(row, col);
                 cellCursor = cell.firstCursorPosition();
-                cellCursor.insertText(texte1, format_cellule);
+                cellCursor.insertText(text1, format_cell);
             }
         }
 
-        //fin de l'edition
+        //end of editing
         cursor.endEditBlock();
-        //impression de editor dans le QPrinter initialisé au début de la fonction
+        //print editor to QPrinter initialized at the beginning of the function
         editor->print(printer);
     }
 }
 
 void Cultures::on_pushButton_supprimer_culture_clicked()
-{   // suppression d'une fiche de culture
-    int ret = QMessageBox::warning(this, tr("Suppression d'une culture"),
-                                   tr("Cette culture peut être supprimer.\n"
-                                      "Confirmer la suppression de la culture"),
+{   // delete a crop record
+    int ret = QMessageBox::warning(this, tr("Delete a crop"),
+                                   tr("This crop can be deleted.\n"
+                                      "Confirm crop deletion"),
                                    QMessageBox::Ok | QMessageBox::Cancel,
                                    QMessageBox::Cancel);
 
@@ -695,19 +695,19 @@ void Cultures::on_pushButton_supprimer_culture_clicked()
         query.exec(str);
         if (!query.isActive())
         {
-            qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() <<
+            qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() <<
                 query.driver();
         }
         else
         {
-            qDebug() << "suppression terminée";
+            qDebug() << "delete finished";
         }
         QSqlQueryModel *model = new QSqlQueryModel;
         model->setQuery("SELECT id, designation, parcelle, date_semis, type_plante , commentaires,etat,duree,date_recolte FROM cultures WHERE parcelle=" + QString::number(
                             m_idItem));
         model->setHeaderData(0, Qt::Vertical, QObject::tr("id"));
         model->setHeaderData(1, Qt::Vertical, QObject::tr("designation"));
-        model->setHeaderData(3, Qt::Vertical, QObject::tr("parcelle"));
+        model->setHeaderData(3, Qt::Vertical, QObject::tr("plot"));
         ui->tableViewCultures->setModel(model);
     }
 
@@ -722,7 +722,7 @@ void Cultures::on_pushButton_supprimer_culture_clicked()
 }
 
 void Cultures::on_pushButton_supprimer_tache_clicked()
-{   //suppression d'une fiche de taches et observations
+{   //delete a task and observation sheet
     QString   strId = ui->lineEdit_id_tache->text();
     QString   str   = "delete from observations where id=" + strId;
     QString   str5  = ui->lineEdit_id_cultures->text();  // id culture
@@ -732,11 +732,11 @@ void Cultures::on_pushButton_supprimer_tache_clicked()
 
     if (!query.isActive())
     {
-        qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
+        qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() << query.driver();
     }
     else
     {
-        qDebug() << "suppression terminée";
+        qDebug() << "delete finished";
     }
 
     QSqlQueryModel *modelObs = new QSqlQueryModel;
@@ -757,16 +757,16 @@ void Cultures::on_lineEdit_duree_textChanged(const QString&arg1)
 }
 
 void Cultures::on_toolButton_FichePlantes_clicked()
-{   // affichage de la fiche des variétés de plantes
+{   // display the plant varieties sheet
     int Id          = ui->comboBox_plante->currentIndex();
     int Num_culture = ui->lineEdit_id_cultures->text().toInt();
 
     if (Id >= 0)
     {
-        Fiche_plantes *fenetre_plante = new Fiche_plantes(Id);
-        int            resultat       = fenetre_plante->exec();
+        Fiche_plantes *plant_sheet = new Fiche_plantes(Id);
+        int            result       = plant_sheet->exec();
 
-        if (resultat == QDialog::Accepted)
+        if (result == QDialog::Accepted)
         {
             QSqlQueryModel *modelM = new QSqlQueryModel;
             modelM->setQuery("SELECT designation,type_lune FROM plantes ORDER BY designation ASC");
@@ -777,17 +777,17 @@ void Cultures::on_toolButton_FichePlantes_clicked()
 }
 
 void Cultures::on_toolButton_NouvellePlante_clicked()
-{   //ajouter une nouvelle variété
-    // affichage de la fiche des variétés de plantes
+{   //add a new variety
+    // display the plant varieties sheet
     int Id          = 0;
     int Num_culture = ui->lineEdit_id_cultures->text().toInt();
 
-    Fiche_plantes *fenetre_plante = new Fiche_plantes(Id);
-    int            resultat       = fenetre_plante->exec();
+    Fiche_plantes *plant_sheet = new Fiche_plantes(Id);
+    int            result       = plant_sheet->exec();
 
-    if (resultat == QDialog::Accepted)
+    if (result == QDialog::Accepted)
     {
-        Id = fenetre_plante->getIdPlante();
+        Id = plant_sheet->getIdPlante();
 
         QSqlQueryModel *modelM = new QSqlQueryModel;
         modelM->setQuery("SELECT designation,type_lune FROM plantes ORDER BY designation ASC");
@@ -795,59 +795,59 @@ void Cultures::on_toolButton_NouvellePlante_clicked()
         init_models(Num_culture);
 
         QSqlQuery query;
-        QString   nom_plante;
-        QString   id_plante = QString::number(Id);
+        QString   plant_name;
+        QString   id_plant = QString::number(Id);
 
-        query.exec(QString("select designation from plantes where id =" + id_plante));
+        query.exec(QString("select designation from plantes where id =" + id_plant));
         if (query.first())
         {
-            nom_plante = query.value(0).toString();
+            plant_name = query.value(0).toString();
 
-            ui->comboBox_plante->setCurrentText(nom_plante);
+            ui->comboBox_plante->setCurrentText(plant_name);
         }
         else
         {
-            qDebug() << "erreur query :" << query.lastError().text() << "  " << query.lastError().databaseText() <<
+            qDebug() << "query error :" << query.lastError().text() << "  " << query.lastError().databaseText() <<
                 query.driver();
-            QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                     tr("Veuillez vérifier que tous les champs soient bien remplis"));
+            QMessageBox::information(this, tr("Recording error"),
+                                     tr("Please check that all fields are filled in correctly"));
         }
     }
 }
 
 void Cultures::on_pushButton_Gantt_clicked()
-{   // ouvrir la fiche des tâches du diagramme gantt
-    Dialog_taches *FicheTaches = new Dialog_taches(0, this);
+{   // open the Gantt chart tasks sheet
+    Dialog_taches *TaskSheet = new Dialog_taches(0, this);
 
     connect(this, SIGNAL(sendText(const QString&)),
-            FicheTaches, SLOT(getIdCulture(const QString&)));
+            TaskSheet, SLOT(getIdCulture(const QString&)));
     if (ui->lineEdit_id_cultures->text() != "0")
     {
         //  emit sendText(ui->lineEdit_id_cultures->text());
-        //  FicheTaches->exec();
-        creer_phase();
+        //  TaskSheet->exec();
+        create_phase();
     }
     else
     {
-        QMessageBox::warning(this, tr("Erreur "),
-                             tr("Veuillez sélectionner une culture svp"));
+        QMessageBox::warning(this, tr("Error"),
+                             tr("Please select a crop"));
     }
 }
 
-void Cultures::creer_phase()
+void Cultures::create_phase()
 {
     QSqlQuery query;
     QString   designation     = util::apos(ui->lineEditDesignation->text());
-    QString   commentaires    = "";
-    QString   depart          = ui->dateEdit->date().toString("dd-MM-yyyy");
-    QString   fin             = ui->dateEdit->date().toString("dd-MM-yyyy");
-    QString   duree           = "1";
-    QString   id_culture      = ui->lineEdit_id_cultures->text();
-    QString   contrainte_date = "0";
-    QString   avancement      = "0";
+    QString   comments    = "";
+    QString   start          = ui->dateEdit->date().toString("dd-MM-yyyy");
+    QString   end             = ui->dateEdit->date().toString("dd-MM-yyyy");
+    QString   duration           = "1";
+    QString   id_crop      = ui->lineEdit_id_cultures->text();
+    QString   date_constraint = "0";
+    QString   progress      = "0";
     QString   type            = "1";
-    QString   id_precedent    = "0";
-    QString   id_PhaseParent;
+    QString   id_previous    = "0";
+    QString   id_ParentPhase;
 
     query.exec(QString("SELECT COUNT(*) FROM tasks"));
     if (query.first())
@@ -855,7 +855,7 @@ void Cultures::creer_phase()
         int NbRowTable = query.value(0).toInt();
         if (NbRowTable > 0)
         {
-            query.exec(QString("SELECT id FROM tasks WHERE NOT EXISTS  (SELECT id FROM tasks WHERE id_culture = " + id_culture +
+            query.exec(QString("SELECT id FROM tasks WHERE NOT EXISTS  (SELECT id FROM tasks WHERE id_culture = " + id_crop +
                                ")"));
             if (query.first())
             {
@@ -867,35 +867,35 @@ void Cultures::creer_phase()
                     if (query.first())
                     {
                         int id_MAX = query.value(0).toInt();
-                        id_PhaseParent = QString::number(id_MAX + 1);
+                        id_ParentPhase = QString::number(id_MAX + 1);
                         qDebug() << "query 1:" << query.lastQuery();
                     }
                     else
                     {
-                        qDebug() << "erreur query 1:" << query.lastError().text() << "  " << query.lastError().databaseText() <<
+                        qDebug() << "query error 1:" << query.lastError().text() << "  " << query.lastError().databaseText() <<
                             query.driver() << query.lastQuery();
                     }
 
                     QString str =
                         "insert into tasks (designation,commentaires, depart, fin, duree,precedent, avancement,type,contrainte_date,phase_parent,id_culture)"
-                        "values('" + designation + "','" + commentaires + "','" + depart + "','" + fin +
-                        "'," + duree + "," + id_precedent + "," + avancement + "," + type + "," + contrainte_date + "," +
-                        id_PhaseParent +
+                        "values('" + designation + "','" + comments + "','" + start + "','" + end +
+                        "'," + duration + "," + id_previous + "," + progress + "," + type + "," + date_constraint + "," +
+                        id_ParentPhase +
                         "," +
-                        id_culture + ")";
+                        id_crop + ")";
                     query.exec(str);
                     if (!query.isActive())
                     {
-                        qDebug() << "erreur query valider:" << query.lastError().text() << "  " <<
+                        qDebug() << "validate query error:" << query.lastError().text() << "  " <<
                             query.lastError().databaseText() <<
                             query.lastQuery().toUtf8();
-                        QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                                 tr("Veuillez vérifier que tous les champs soient bien remplis"));
+                        QMessageBox::information(this, tr("Recording error"),
+                                                 tr("Please check that all fields are filled in correctly"));
                     }
                     else
                     {
-                        QMessageBox::information(this, tr("Enregistrement de la phase culture "),
-                                                 tr("La phase de culture a été crée avec succès !"));
+                        QMessageBox::information(this, tr("Crop phase recording"),
+                                                 tr("The crop phase has been successfully created!"));
                     }
                 }
                 else
@@ -905,33 +905,33 @@ void Cultures::creer_phase()
             }
             else
             {
-                QMessageBox::warning(this, tr("Erreur "),
-                                     tr("Cette phase de culture est existante !"));
-                qDebug() << "erreur query 3:" << query.lastError().text() << "  " << query.lastError().databaseText() <<
+                QMessageBox::warning(this, tr("Error"),
+                                     tr("This crop phase already exists!"));
+                qDebug() << "query error 3:" << query.lastError().text() << "  " << query.lastError().databaseText() <<
                     query.driver() << query.lastQuery();
             }
         }
         else
         {
-            id_PhaseParent = QString::number(1);
+            id_ParentPhase = QString::number(1);
             QString str =
                 "insert into tasks (designation,commentaires, depart, fin, duree,precedent, avancement,type,contrainte_date,phase_parent,id_culture)"
-                "values('" + designation + "','" + commentaires + "','" + depart + "','" + fin +
-                "'," + duree + "," + id_precedent + "," + avancement + "," + type + "," + contrainte_date + "," + id_PhaseParent +
+                "values('" + designation + "','" + comments + "','" + start + "','" + end +
+                "'," + duration + "," + id_previous + "," + progress + "," + type + "," + date_constraint + "," + id_ParentPhase +
                 "," +
-                id_culture + ")";
+                id_crop + ")";
             query.exec(str);
             if (!query.isActive())
             {
-                qDebug() << "erreur query valider:" << query.lastError().text() << "  " << query.lastError().databaseText() <<
+                qDebug() << "validate query error:" << query.lastError().text() << "  " << query.lastError().databaseText() <<
                     query.lastQuery().toUtf8();
-                QMessageBox::information(this, tr("Erreur d'enregistrement"),
-                                         tr("Veuillez vérifier que tous les champs soient bien remplis"));
+                QMessageBox::information(this, tr("Recording error"),
+                                         tr("Please check that all fields are filled in correctly"));
             }
             else
             {
-                QMessageBox::information(this, tr("Enregistrement de la phase culture "),
-                                         tr("La phase de culture a été crée avec succès !"));
+                QMessageBox::information(this, tr("Crop phase recording"),
+                                         tr("The crop phase has been successfully created!"));
             }
         }
     }

--- a/dialogs/cultures.h
+++ b/dialogs/cultures.h
@@ -55,42 +55,42 @@ public:
     }
 
     void init_models(int idculture);
-    void creer_phase();
+    void create_phase();
 
 private slots:
-    void on_pushButton_validerData_clicked();
+    void on_pushButton_validateData_clicked();
 
     void on_tableViewCultures_clicked(const QModelIndex&index);
 
     void on_lineEditTypeLune_textChanged(const QString&arg1);
 
-    void on_pushButton_modifier_clicked();
+    void on_pushButton_modify_clicked();
 
-    void on_pushButton_nouvelleOperation_clicked();
+    void on_pushButton_newOperation_clicked();
 
-    void on_pushButton_print_fiche_clicked();
+    void on_pushButton_print_sheet_clicked();
 
-    void on_comboBox_plante_currentIndexChanged(const QString&arg1);
+    void on_comboBox_plant_currentIndexChanged(const QString&arg1);
 
-    void on_pushButton_creer_tache_clicked();
+    void on_pushButton_create_task_clicked();
 
-    void on_tableView_taches_clicked(const QModelIndex&index);
+    void on_tableView_tasks_clicked(const QModelIndex&index);
 
-    void on_pushButton_modifier_tache_clicked();
+    void on_pushButton_modify_task_clicked();
 
     void on_lineEdit_id_cultures_textChanged(const QString&arg1);
 
-    void on_pushButton_supprimer_culture_clicked();
+    void on_pushButton_delete_crop_clicked();
 
-    void on_pushButton_supprimer_tache_clicked();
+    void on_pushButton_delete_task_clicked();
 
-    void on_lineEdit_duree_textChanged(const QString&arg1);
+    void on_lineEdit_duration_textChanged(const QString&arg1);
 
 
 
-    void on_toolButton_FichePlantes_clicked();
+    void on_toolButton_PlantSheets_clicked();
 
-    void on_toolButton_NouvellePlante_clicked();
+    void on_toolButton_NewPlant_clicked();
 
     void on_pushButton_Gantt_clicked();
 

--- a/dialogs/cultures.ui
+++ b/dialogs/cultures.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>FICHE CULTURE</string>
+   <string>CROP SHEET</string>
   </property>
   <property name="windowIcon">
    <iconset resource="../libreJardin.qrc">
@@ -47,7 +47,7 @@
           </font>
          </property>
          <property name="text">
-          <string>FICHE CULTURE DE LA PARCELLE</string>
+          <string>PLOT CROP SHEET</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -116,7 +116,7 @@
                </size>
               </property>
               <property name="text">
-               <string>Type lune : </string>
+               <string>Moon type : </string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -126,14 +126,14 @@
             <item row="1" column="2">
              <widget class="QLabel" name="label_3">
               <property name="text">
-               <string>Date de fin de culture</string>
+               <string>End of cultivation date</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="label_10">
               <property name="text">
-               <string>Id culture</string>
+               <string>Crop Id</string>
               </property>
              </widget>
             </item>
@@ -176,7 +176,7 @@
                 <item>
                  <widget class="QToolButton" name="toolButton_FichePlantes">
                   <property name="toolTip">
-                   <string>Visualiser la fiche de la variété</string>
+                   <string>View variety sheet</string>
                   </property>
                   <property name="text">
                    <string>...</string>
@@ -198,7 +198,7 @@
               <item>
                <widget class="QToolButton" name="toolButton_NouvellePlante">
                 <property name="toolTip">
-                 <string>Ajouter une nouvelle variété</string>
+                 <string>Add a new variety</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -241,7 +241,7 @@
               <item>
                <widget class="QPushButton" name="pushButton_print_fiche">
                 <property name="text">
-                 <string>Imprimer la fiche</string>
+                 <string>Print Sheet</string>
                 </property>
                </widget>
               </item>
@@ -273,21 +273,21 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>Enregistrer modifications</string>
+                 <string>Save Changes</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QPushButton" name="pushButton_supprimer_culture">
                 <property name="text">
-                 <string>Supprimer</string>
+                 <string>Delete</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QPushButton" name="pushButton_nouvelleOperation">
                 <property name="text">
-                 <string>Nouvelle fiche vierge</string>
+                 <string>New Blank Sheet</string>
                 </property>
                </widget>
               </item>
@@ -306,7 +306,7 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>Créer nouvelle culture</string>
+                 <string>Create New Crop</string>
                 </property>
                </widget>
               </item>
@@ -351,7 +351,7 @@
                </size>
               </property>
               <property name="text">
-               <string>Date de mise en culture </string>
+               <string>Cultivation start date</string>
               </property>
              </widget>
             </item>
@@ -406,7 +406,7 @@
                </size>
               </property>
               <property name="text">
-               <string>Commentaires</string>
+               <string>Comments</string>
               </property>
              </widget>
             </item>
@@ -442,14 +442,14 @@
                </size>
               </property>
               <property name="text">
-               <string>Durée prévisionelle (en jours)</string>
+               <string>Estimated duration (in days)</string>
               </property>
              </widget>
             </item>
             <item row="7" column="0">
              <widget class="QLabel" name="label_18">
               <property name="text">
-               <string>Espèce :</string>
+               <string>Species:</string>
               </property>
              </widget>
             </item>
@@ -462,14 +462,14 @@
                </size>
               </property>
               <property name="text">
-               <string>Parcelle</string>
+               <string>Plot</string>
               </property>
              </widget>
             </item>
             <item row="7" column="3">
              <widget class="QLabel" name="label_19">
               <property name="text">
-               <string>Famille :</string>
+               <string>Family:</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -480,22 +480,22 @@
              <widget class="QComboBox" name="comboBox_etat_culture">
               <item>
                <property name="text">
-                <string>Parcelle en simple culture </string>
+                <string>Plot in single crop</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Parcelle en double culture (ligne haute)</string>
+                <string>Plot in double crop (high line)</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Parcelle en double culture (ligne basse)</string>
+                <string>Plot in double crop (low line)</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Parcelle en attente</string>
+                <string>Plot on hold</string>
                </property>
               </item>
              </widget>
@@ -515,7 +515,7 @@
                <number>9</number>
               </property>
               <property name="text">
-               <string>Variété  : </string>
+               <string>Variety : </string>
               </property>
              </widget>
             </item>
@@ -551,7 +551,7 @@
             <item row="2" column="4" colspan="2">
              <widget class="QPushButton" name="pushButton_Gantt">
               <property name="text">
-               <string>Intégrer cette culture dans Gantt</string>
+               <string>Integrate this crop into Gantt</string>
               </property>
              </widget>
             </item>
@@ -578,7 +578,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Liste des cultures  réalisées sur cette parcelle</string>
+            <string>List of crops grown on this plot</string>
            </property>
           </widget>
          </item>
@@ -653,7 +653,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Observations concernant cette culture</string>
+                 <string>Observations concerning this crop</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
@@ -715,7 +715,7 @@
                  <enum>Qt::LeftToRight</enum>
                 </property>
                 <property name="text">
-                 <string>Type d'observation. : </string>
+                 <string>Observation type. : </string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -812,14 +812,14 @@
               </size>
              </property>
              <property name="text">
-              <string>Enregistrer modifications</string>
+              <string>Save Changes</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QPushButton" name="pushButton_supprimer_tache">
              <property name="text">
-              <string>Supprimer</string>
+              <string>Delete</string>
              </property>
             </widget>
            </item>
@@ -838,7 +838,7 @@
               </size>
              </property>
              <property name="text">
-              <string>Créer nouvelle observation</string>
+              <string>Create New Observation</string>
              </property>
             </widget>
            </item>
@@ -867,7 +867,7 @@
             </font>
            </property>
            <property name="text">
-            <string>Liste des observations  concernant  cette culture</string>
+            <string>List of observations concerning this crop</string>
            </property>
           </widget>
          </item>

--- a/dialogs/detail_parcelle.h
+++ b/dialogs/detail_parcelle.h
@@ -20,7 +20,7 @@ class detail_parcelle : public QDialog
 public:
     explicit detail_parcelle(const int&IdParcelle, const QString&fileName, QWidget *parent = nullptr);
     ~detail_parcelle();
-    void ouvrir_FichierXML(QString fileName);
+    void open_XMLFile(QString fileName);
 
 
     void setIdParcelle(const int&idParcelle)
@@ -61,23 +61,23 @@ public:
     QPolygon convertStrToPoly(const QString MyString);
 
 private slots:
-    void on_pushButton_ouvrir_clicked();
+    void on_pushButton_open_clicked();
     void Item_clicked();
     int get_MaxId();
 
-    void on_toolButton_Sauver_clicked();
+    void on_toolButton_Save_clicked();
 
-    void on_toolButton_AjoutRectangle_clicked();
+    void on_toolButton_AddRectangle_clicked();
 
-    void on_toolButton_AjoutCercle_clicked();
+    void on_toolButton_AddCircle_clicked();
 
-    void on_comboBox_epaisseurLignes_P_currentIndexChanged(const QString&arg1);
+    void on_comboBox_lineWidth_P_currentIndexChanged(const QString&arg1);
 
-    void on_comboBox_typeLigne_P_currentIndexChanged(int index);
+    void on_comboBox_lineType_P_currentIndexChanged(int index);
 
-    void on_toolButton_CouleurCrayon_clicked();
+    void on_toolButton_PenColor_clicked();
 
-    void on_toolButton_CouleurFond_clicked();
+    void on_toolButton_BackgroundColor_clicked();
 
     void on_pushButton_zoomIn_clicked();
 
@@ -86,19 +86,19 @@ private slots:
 
     void on_toolButton_modification_clicked();
 
-    void on_toolButtonUtilisation_clicked();
+    void on_toolButton_Usage_clicked();
 
     void on_toolButton_clicked();
 
     void on_toolButton_2_clicked();
 
-    void on_toolButton_supprimer_clicked();
+    void on_toolButton_delete_clicked();
 
-    void on_toolButton_devant_clicked();
+    void on_toolButton_front_clicked();
 
     void on_toolButton_save_as_clicked();
 
-    void on_pushButton_Affiches_fiche_clicked();
+    void on_pushButton_DisplaySheet_clicked();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -110,7 +110,7 @@ private:
     int m_MaxId;
     QString m_fileName_XML;
     QString m_fileName_SQL;
-    QList <Parcelle *> parcelleList;
+    QList <Parcelle *> plotList; // Changed variable name
     QString m_fileNameBackGround;
     qreal m_ZoomRatio;
     int m_mode;

--- a/dialogs/detail_parcelle.ui
+++ b/dialogs/detail_parcelle.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Détail d'une parcelle</string>
+   <string>Plot Details</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
@@ -54,7 +54,7 @@
            <item>
             <widget class="QLabel" name="label">
              <property name="text">
-              <string>Parcelle: </string>
+              <string>Plot: </string>
              </property>
             </widget>
            </item>
@@ -125,14 +125,14 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Désignation de la parcelle sélectionnée</string>
+              <string>Designation of the selected plot</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QToolButton" name="toolButton">
              <property name="toolTip">
-              <string>Valider la désignation et les commentaires</string>
+              <string>Validate designation and comments</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -161,7 +161,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Ouvre un plan existant</string>
+              <string>Open an existing plan</string>
              </property>
              <property name="text">
               <string/>
@@ -193,7 +193,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Enregistre le plan pour cette parcelle</string>
+              <string>Save the plan for this plot</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -228,7 +228,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Enregistrer le plan sous..</string>
+              <string>Save the plan as..</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -251,7 +251,7 @@
            <item>
             <widget class="QToolButton" name="toolButtonUtilisation">
              <property name="toolTip">
-              <string>Mode utilisation</string>
+              <string>Usage mode</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -277,7 +277,7 @@
            <item>
             <widget class="QToolButton" name="toolButton_modification">
              <property name="toolTip">
-              <string>Mode dessin</string>
+              <string>Drawing mode</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -315,7 +315,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Dessiner un rectangle</string>
+              <string>Draw a rectangle</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -350,7 +350,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Dessiner un cercle</string>
+              <string>Draw a circle</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -373,7 +373,7 @@
            <item>
             <widget class="QToolButton" name="toolButton_devant">
              <property name="toolTip">
-              <string>mettre en avant</string>
+              <string>Bring to front</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -396,7 +396,7 @@
            <item>
             <widget class="QToolButton" name="toolButton_supprimer">
              <property name="toolTip">
-              <string>Supprimer l'objet</string>
+              <string>Delete object</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -419,7 +419,7 @@
            <item>
             <widget class="QToolButton" name="toolButton_2">
              <property name="toolTip">
-              <string>Quitter </string>
+              <string>Exit</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -481,7 +481,7 @@
                 </font>
                </property>
                <property name="text">
-                <string>Epaisseur</string>
+                <string>Thickness</string>
                </property>
               </widget>
              </item>
@@ -506,7 +506,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Définir l'épaisseur de la ligne</string>
+                <string>Define line thickness</string>
                </property>
                <item>
                 <property name="text">
@@ -577,7 +577,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Choisir la couleur des lignes et caractères</string>
+              <string>Choose line and character color</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -613,7 +613,7 @@
                 </font>
                </property>
                <property name="text">
-                <string>Couleur Crayon</string>
+                <string>Pen Color</string>
                </property>
               </widget>
              </item>
@@ -632,7 +632,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Couleur du trait de la parcelle ou ligne</string>
+                <string>Color of the plot or line stroke</string>
                </property>
                <property name="frameShape">
                 <enum>QFrame::Panel</enum>
@@ -653,7 +653,7 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Choisir la couleur de la parcelle</string>
+              <string>Choose plot color</string>
              </property>
              <property name="text">
               <string>...</string>
@@ -689,7 +689,7 @@
                 </font>
                </property>
                <property name="text">
-                <string>Couleur fond</string>
+                <string>Background Color</string>
                </property>
               </widget>
              </item>
@@ -708,7 +708,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Couleur du fond de la parcelle</string>
+                <string>Plot background color</string>
                </property>
                <property name="frameShape">
                 <enum>QFrame::Panel</enum>
@@ -723,26 +723,26 @@
            <item>
             <widget class="QComboBox" name="comboBox_typeLigne_P">
              <property name="toolTip">
-              <string>Définir le type de ligne</string>
+              <string>Define line type</string>
              </property>
              <item>
               <property name="text">
-               <string>ligne pleine</string>
+               <string>Solid line</string>
               </property>
              </item>
              <item>
               <property name="text">
-               <string>tirets longs</string>
+               <string>Long dashes</string>
               </property>
              </item>
              <item>
               <property name="text">
-               <string>tirets courts</string>
+               <string>Short dashes</string>
               </property>
              </item>
              <item>
               <property name="text">
-               <string>axe</string>
+               <string>Axis</string>
               </property>
              </item>
             </widget>
@@ -819,7 +819,7 @@
                 </font>
                </property>
                <property name="toolTip">
-                <string>Ratio du zoom</string>
+                <string>Zoom ratio</string>
                </property>
                <property name="text">
                 <string>1</string>
@@ -877,10 +877,10 @@
               </size>
              </property>
              <property name="toolTip">
-              <string>Afficher la fiche culture correspondante à la parcelle</string>
+              <string>Display the crop sheet corresponding to the plot</string>
              </property>
              <property name="text">
-              <string>Fiche culture</string>
+              <string>Crop Sheet</string>
              </property>
              <property name="icon">
               <iconset resource="../libreJardin.qrc">
@@ -939,7 +939,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Observations sur la parcelle sélectionnée</string>
+            <string>Observations on the selected plot</string>
            </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>


### PR DESCRIPTION
This commit includes the translation of several core dialog components from French to English. The following files and elements were translated:

- dialogs/configuration.cpp: Translated comments and string literals.
- dialogs/configuration.h: Translated comments, function names (e.g., setXmlFilName to setXmlFileName), and variable names (e.g., m_xmlFilName to m_xmlFileName).
- dialogs/configuration.ui: Translated UI text for labels, buttons, and other elements.

- dialogs/cultures.cpp: Translated comments and string literals.
- dialogs/cultures.h: Translated comments and function names (e.g., creer_phase to create_phase).
- dialogs/cultures.ui: Translated UI text.

- dialogs/detail_parcelle.cpp: Translated comments and string literals. Function names were also anglicized (e.g., ouvrir_FichierXML to open_XMLFile).
- dialogs/detail_parcelle.h: Translated comments, function names (e.g., on_pushButton_ouvrir_clicked to on_pushButton_open_clicked), and variable names (e.g., parcelleList to plotList).
- dialogs/detail_parcelle.ui: Translated UI text.

This is the first part of a larger effort to translate the entire application to English.