### PR TITLE
Add configurable zero-fill utility

### DIFF
--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -11,6 +11,8 @@ class TestUtil : public QObject
 private slots:
     void afficheZeros_data();
     void afficheZeros();
+    void afficheZerosDigits_data();
+    void afficheZerosDigits();
     void apos_data();
     void apos();
     void getLocale();
@@ -32,6 +34,25 @@ void TestUtil::afficheZeros()
     QFETCH(QString, input);
     QFETCH(QString, expected);
     QCOMPARE(util::afficheZeros(input), expected);
+}
+
+void TestUtil::afficheZerosDigits_data()
+{
+    QTest::addColumn<QString>("input");
+    QTest::addColumn<int>("digits");
+    QTest::addColumn<QString>("expected");
+
+    QTest::newRow("three digits with decimal") << QString("1.2") << 3 << QString("1.200");
+    QTest::newRow("three digits integer") << QString("3") << 3 << QString("3.000");
+    QTest::newRow("one digit existing") << QString("2.34") << 1 << QString("2.34");
+}
+
+void TestUtil::afficheZerosDigits()
+{
+    QFETCH(QString, input);
+    QFETCH(int, digits);
+    QFETCH(QString, expected);
+    QCOMPARE(util::afficheZeros(input, digits), expected);
 }
 
 void TestUtil::apos_data()

--- a/utilitaires/util.cpp
+++ b/utilitaires/util.cpp
@@ -14,27 +14,26 @@ QString util::apos(QString texte)
     return texteModif;
 }
 
-QString util::afficheZeros(QString texte)
+QString util::afficheZeros(QString texte, int digits)
 {
+    // replace comma with dot for decimal separator
     texte.replace(QString(","), QString("."));
     int index = texte.indexOf('.');
+
     if (index >= 0)
     {
-        int digits = texte.length() - index - 1;
-
-        if (digits == 0)
-        {
-            texte += "00";
-        }
-        else if (digits == 1)
+        int currentDigits = texte.length() - index - 1;
+        while (currentDigits < digits)
         {
             texte += '0';
+            ++currentDigits;
         }
-        // if digits >= 2 do nothing
+        // keep existing digits if there are more than requested
     }
     else
     {
-        texte += ".00";
+        // no decimal part - add one filled with zeros
+        texte += '.' + QString(digits, '0');
     }
     return texte;
 }

--- a/utilitaires/util.h
+++ b/utilitaires/util.h
@@ -7,7 +7,7 @@ class util
 public:
     util();
     static QString apos(const QString texte);   // replace apostrophes for SQL queries
-    static QString afficheZeros(QString texte); // zero-fill at the end of the string
+    static QString afficheZeros(QString texte, int digits = 2); // zero-fill at the end of the string with configurable precision
     static QString getLocale();
 };
 


### PR DESCRIPTION
## Summary
- extend `afficheZeros` to accept configurable number of digits
- update util headers
- add new unit tests for extended functionality

## Testing
- `qmake test_util.pro`
- `make`
- `QT_QPA_PLATFORM=offscreen ./test_util`

------
https://chatgpt.com/codex/tasks/task_e_6841c1138cb8832092543ac4dbad444c