### PR TITLE
Fix build errors

### DIFF
--- a/dialogs/configuration.cpp
+++ b/dialogs/configuration.cpp
@@ -26,7 +26,8 @@ Configuration::Configuration(const QString&fileNameXML, const QString&fileNameSQ
     init_base();
     ui->lineEdit_config_nom_Xml->setText(fileNameXML);
     ui->lineEdit_config_nom_base->setText(fileNameSQL);
-    setXmlFilName(fileNameXML);
+    // store filenames for later use
+    setXmlFileName(fileNameXML);
     setSqlFileName(fileNameSQL);
 }
 
@@ -120,7 +121,8 @@ void Configuration::on_pushButton_changeDataBase_clicked()
     }
 }
 
-void Configuration::enregistrerDataBase()
+// save database filename to a new XML file
+void Configuration::saveDataBase()
 {
     // save the name of the database in the XML file
     QString      cellvalue;

--- a/dialogs/configuration.h
+++ b/dialogs/configuration.h
@@ -54,20 +54,20 @@ private slots:
 
     void on_pushButton_export_clicked();
 
-    void on_pushButton_Modify_operations_clicked();
+    void on_pushButton_Modifier_operations_clicked();
 
-    void on_pushButton_Delete_operations_clicked();
+    void on_pushButton_Supprimer_operations_clicked();
 
-    void on_pushButton_New_operations_clicked();
+    void on_pushButton_Nouveau_operations_clicked();
 
-    void on_pushButton_save_operations_clicked();
+    void on_pushButton_enregistrer_operations_clicked();
 
-    void on_tableView_tasks_clicked(const QModelIndex&index);
+    void on_tableView_taches_clicked(const QModelIndex&index);
 
-    void on_pushButton_close_clicked();
+    void on_pushButton_fermer_clicked();
 
 
-    void on_pushButton_update_clicked();
+    void on_pushButton_mise_a_jour_clicked();
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/dialogs/cultures.h
+++ b/dialogs/cultures.h
@@ -58,39 +58,39 @@ public:
     void create_phase();
 
 private slots:
-    void on_pushButton_validateData_clicked();
+    void on_pushButton_validerData_clicked();
 
     void on_tableViewCultures_clicked(const QModelIndex&index);
 
     void on_lineEditTypeLune_textChanged(const QString&arg1);
 
-    void on_pushButton_modify_clicked();
+    void on_pushButton_modifier_clicked();
 
-    void on_pushButton_newOperation_clicked();
+    void on_pushButton_nouvelleOperation_clicked();
 
-    void on_pushButton_print_sheet_clicked();
+    void on_pushButton_print_fiche_clicked();
 
-    void on_comboBox_plant_currentIndexChanged(const QString&arg1);
+    void on_comboBox_plante_currentIndexChanged(const QString&arg1);
 
-    void on_pushButton_create_task_clicked();
+    void on_pushButton_creer_tache_clicked();
 
-    void on_tableView_tasks_clicked(const QModelIndex&index);
+    void on_tableView_taches_clicked(const QModelIndex&index);
 
-    void on_pushButton_modify_task_clicked();
+    void on_pushButton_modifier_tache_clicked();
 
     void on_lineEdit_id_cultures_textChanged(const QString&arg1);
 
-    void on_pushButton_delete_crop_clicked();
+    void on_pushButton_supprimer_culture_clicked();
 
-    void on_pushButton_delete_task_clicked();
+    void on_pushButton_supprimer_tache_clicked();
 
-    void on_lineEdit_duration_textChanged(const QString&arg1);
+    void on_lineEdit_duree_textChanged(const QString&arg1);
 
 
 
-    void on_toolButton_PlantSheets_clicked();
+    void on_toolButton_FichePlantes_clicked();
 
-    void on_toolButton_NewPlant_clicked();
+    void on_toolButton_NouvellePlante_clicked();
 
     void on_pushButton_Gantt_clicked();
 

--- a/dialogs/detail_parcelle.cpp
+++ b/dialogs/detail_parcelle.cpp
@@ -59,39 +59,6 @@ void detail_parcelle::closeEvent(QCloseEvent *event)
 {
     Q_UNUSED(event);
     accept();
-    // translator
-    QTranslator translator;
-    QString     fileContent = ":/translations/open-jardin_" + util::getLocale();
-
-    translator.load(fileContent);
-    qApp->installTranslator(&translator);
-
-    ui->setupUi(this);
-    setFileNameXML(fileName); //name of the detail plan file
-    scene = new QGraphicsScene(this);
-    scene->setSceneRect(0, 0, 1900, 1200);
-    scene->setItemIndexMethod(QGraphicsScene::BspTreeIndex);
-    ui->graphicsView->setScene(scene);
-    // if the item selection changes, launch the command
-    connect(scene, SIGNAL(selectionChanged()), this, SLOT(Item_clicked()));
-    m_ZoomRatio = 1;  //zoom factor variable (actual size =1 )
-    ui->label_parcelle->setText(QString::number(IdParcelle));
-    setIdParcelle(IdParcelle);
-    if (fileName != "")
-    {
-        open_XMLFile(fileName);
-    }
-}
-
-detail_parcelle::~detail_parcelle()
-{
-    delete ui;
-}
-
-void detail_parcelle::closeEvent(QCloseEvent *event)
-{
-    Q_UNUSED(event);
-    accept();
     close();
 }
 
@@ -101,7 +68,8 @@ void detail_parcelle::open_XMLFile(QString fileName)
     QString      field;
     QFile        fileHandle(fileName);
 
-    parcelleList.clear();
+    // clear existing plots list
+    plotList.clear();
     qDebug() << " xml file " << fileName;
     if (fileHandle.exists())
     {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3862,7 +3862,8 @@ void MainWindow::on_actionConfiguration_triggered()
 
     if (resultat == QDialog::Accepted)
     {
-        setFileNameXML(fenetre_configuration->getXmlFilName());
+        // use the correct accessor to retrieve the XML file name
+        setFileNameXML(fenetre_configuration->getXmlFileName());
         setfileNameSQL(fenetre_configuration->getSqlFileName());
 
         qDebug() << " base de données ouverte " << getfileNameSQL() << " XML " << getFileNameXML();


### PR DESCRIPTION
## Summary
- fix typo in Configuration getter call
- align slot names between headers and implementations
- remove duplicated functions and unused variable in detail_parcelle
- regenerate project build files

## Testing
- `qmake libreJardin.pro`
- `make -j$(nproc)`
- `cd tests && qmake test_util.pro && make && ./test_util` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3490198832086784e76ee243c12